### PR TITLE
refactor: 로그인 확인 여부 로직 변경

### DIFF
--- a/src/components/Auth/Login.jsx
+++ b/src/components/Auth/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Axios from 'axios';
+import token from '../../utils/token';
 import { Wrapper, LoginForm, H4, Input, Button, StyledLink } from '../../styles/Style';
 
 function Login() {
@@ -31,7 +32,7 @@ function Login() {
         },
       }
     ).then((res) => {
-      localStorage.setItem('token', res.data.access_token);
+      token.setToken(res.data.access_token);
       navigate('/todo');
     });
   }

--- a/src/components/Auth/Login.jsx
+++ b/src/components/Auth/Login.jsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Axios from 'axios';
-import { isLogin } from '../../utils/isLogin';
 import { Wrapper, LoginForm, H4, Input, Button, StyledLink } from '../../styles/Style';
 
 function Login() {
@@ -11,14 +10,6 @@ function Login() {
   const emailIsValid = (email) => email?.includes('@');
   const passwordIsValid = (password) => password?.length > 7;
   const formIsValid = emailIsValid(loginData.email) && passwordIsValid(loginData.password);
-
-  useEffect(() => {
-    if (isLogin()) {
-      navigate('/todo');
-    } else {
-      navigate('/');
-    }
-  }, [navigate]);
 
   function onChangeHandle(e) {
     const { value, name } = e.target;

--- a/src/components/Auth/SignUp.jsx
+++ b/src/components/Auth/SignUp.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Axios from 'axios';
+import token from '../../utils/token';
 import { Wrapper, LoginForm, H4, Input, Button, StyledLink } from '../../styles/Style';
 
 function SignUp() {
@@ -31,9 +32,11 @@ function SignUp() {
           'Content-Type': 'application/json',
         },
       }
-    );
-    alert('회원가입이 완료되었습니다!');
-    navigate('/');
+    ).then((res) => {
+      token.setToken(res.data.access_token);
+      alert('회원가입이 완료되었습니다!');
+      navigate('/todo');
+    });
   }
   return (
     <Wrapper>

--- a/src/components/Todo/Todo.jsx
+++ b/src/components/Todo/Todo.jsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Axios from 'axios';
-import { isLogin } from '../../utils/isLogin';
 import { Wrapper, TodoInput, Button, TodoBtn, Span, LiWrapper } from '../../styles/Style';
 
 function Todo() {
@@ -12,14 +10,9 @@ function Todo() {
   const [updateText, setUpdateText] = useState(text);
   const [isCompleted, setIsCompleted] = useState(false);
   const token = localStorage.getItem('token');
-  const navigate = useNavigate();
 
   useEffect(() => {
-    if (isLogin()) {
-      getTodo();
-    } else {
-      navigate('/');
-    }
+    getTodo();
   }, [todoData]);
 
   function checkedCompleted(e) {
@@ -102,9 +95,9 @@ function Todo() {
             </TodoBtn>
           </li>
         ) : (
-          todoData?.map((todo) => {
-            return (
-              <LiWrapper>
+          <LiWrapper>
+            {todoData?.map((todo) => {
+              return (
                 <li key={todo.id}>
                   {todo.isCompleted ? (
                     <Span state={'completed'}>완료!</Span>
@@ -127,9 +120,9 @@ function Todo() {
                     삭제
                   </TodoBtn>
                 </li>
-              </LiWrapper>
-            );
-          })
+              );
+            })}
+          </LiWrapper>
         )}
       </ul>
     </Wrapper>

--- a/src/components/Todo/Todo.jsx
+++ b/src/components/Todo/Todo.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Axios from 'axios';
+import token from '../../utils/token';
 import { Wrapper, TodoInput, Button, TodoBtn, Span, LiWrapper } from '../../styles/Style';
 
 function Todo() {
@@ -9,7 +10,7 @@ function Todo() {
   const [updateId, setUpdateId] = useState('');
   const [updateText, setUpdateText] = useState(text);
   const [isCompleted, setIsCompleted] = useState(false);
-  const token = localStorage.getItem('token');
+  const userToken = token.getToken();
 
   useEffect(() => {
     getTodo();
@@ -22,7 +23,7 @@ function Todo() {
   async function getTodo() {
     await Axios.get(`https://pre-onboarding-selection-task.shop/todos`, {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${userToken}`,
       },
     }).then((res) => setTodoData(res.data));
   }
@@ -33,7 +34,7 @@ function Todo() {
       { todo: text },
       {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${userToken}`,
           'Content-Type': 'application/json',
         },
       }
@@ -43,7 +44,7 @@ function Todo() {
   async function deleteTodo(id) {
     await Axios.delete(`https://pre-onboarding-selection-task.shop/todos/${id}`, {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${userToken}`,
       },
     });
   }
@@ -54,7 +55,7 @@ function Todo() {
       { todo: updateText, isCompleted },
       {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${userToken}`,
           'Content-Type': 'application/json',
         },
       }

--- a/src/routers/PrivateRoute.jsx
+++ b/src/routers/PrivateRoute.jsx
@@ -1,0 +1,14 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import token from '../utils/token';
+
+function PrivateRoute({ authenticationRequired }) {
+  const isLogin = token.getToken();
+
+  if (authenticationRequired) {
+    return isLogin ? <Outlet /> : <Navigate to='/' />;
+  }
+
+  return isLogin ? <Navigate to='/todo' /> : <Outlet />;
+}
+
+export default PrivateRoute;

--- a/src/routers/Router.jsx
+++ b/src/routers/Router.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import PrivateRoute from './PrivateRoute';
 import Login from '../components/Auth/Login';
 import SignUp from '../components/Auth/SignUp';
 import Todo from '../components/Todo/Todo';
@@ -7,9 +8,13 @@ function Router() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path='/' element={<Login />} />
-        <Route path='/signup' element={<SignUp />} />
-        <Route path='/todo' element={<Todo />} />
+        <Route element={<PrivateRoute authenticationRequired />}>
+          <Route path='/todo' element={<Todo />} />
+        </Route>
+        <Route element={<PrivateRoute authenticationRequired={false} />}>
+          <Route path='/' element={<Login />} />
+          <Route path='/signup' element={<SignUp />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/styles/Style.jsx
+++ b/src/styles/Style.jsx
@@ -10,7 +10,7 @@ export const Wrapper = styled.section`
   margin: 0 auto;
 `;
 
-export const LiWrapper = styled.li`
+export const LiWrapper = styled.ul`
   margin-bottom: 10px;
 
   & {

--- a/src/utils/isLogin.js
+++ b/src/utils/isLogin.js
@@ -1,7 +1,0 @@
-export function isLogin() {
-  if (localStorage.getItem('token')) {
-    return true;
-  } else {
-    return false;
-  }
-}

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,0 +1,6 @@
+const token = {
+  setToken: (userToken) => localStorage.setItem('token', userToken),
+  getToken: () => localStorage.getItem('token'),
+};
+
+export default token;


### PR DESCRIPTION
### 관련 이슈

#1 3. 로그인 확인 여부

### 고민했던 점

**1. 어떻게 개선을 해야할까?**

개선하면서 컴포넌트의 역할에 대해 고민을 해봤다.
사실 이전에 구현한 것 처럼 `useEffect`로 `token`을 확인하고 `useNavigate` hook을 사용하여 해당 페이지로 이동시켜도 큰 문제는 되지 않는다.
그래서 문제라고 생각했었던 부분인 **동일한 로직이 컴포넌트 각각에 작성**되어 있는 점을
커스텀 훅으로 생성하는 방향으로 개선하고자 하였다.

하지만 페이지가 렌더링 되기 전 토큰을 확인하고 적절한 페이지로 이동시키는 것은 `Router`에서 해야하는 역할이라는 생각이 들었고,
커스텀 훅을 만들기보단 `Private Route`를 만들어 **라우팅 단계에서 토큰 여부를 확인하고 올바른 페이지로 라우팅**되도록 해야겠다는 판단을 했다.

**2. 어떻게 구현을 해야할까?**

처음엔 간단하게 토큰 여부를 확인하고 `token`이 있다면 `<Outlet />`을 렌더링시켜 `todo` 페이지로 이동시키고,
기본적으로 `<Navigate to='/' />`를 반환하여 `login` 페이지로 이동되도록 개선했다.
하지만 구현해보니 **로그인을 해도, 하지않아도 회원가입 페이지에 접근할 수 있다**는걸 알았다.

그래서 `token`이 있다면 `<Navigate to='/todo' />`를 반환하여 `todo` 페이지로 이동되도록 하고,
기본적으로 `<Outlet />`을 렌더링시켜 `login`, `signup` 페이지에 접근할 수 있도록 수정했다.
이렇게 하고보니 파일 이름은 `PrivateRoute`인데, 이름과는 정반대의 기능을 하고있는 느낌이 들었다.

결론적으로 처음 개선 방안이었던 로직으로 되돌아가고, **`authenticationRequired` 인자 값을 추가**하여
**인증이 필요한 페이지인지, 필요 없는 페이지인지 구분할 수 있도록 하여 조건을 추가**하였다. (자세한 코드는 아래에!)

### 변경 사항

**Before**:
1. 페이지 접속 시 useEffect 사용하여 token 여부 확인한 뒤, token이 있다면 todo페이지로, 없다면 login페이지로 이동하도록 Login, Todo 컴포넌트 내에서  기능 구현

	```jsx
	useEffect(() => {
	  if (isLogin()) {
	    navigate('/todo');
	  } else {
	    navigate('/');
	  }
	}, [navigate]);
	```

2. localStorage 메서드 사용 시 필요한 곳에서 각각 실행 (Login, SignUp, Todo 컴포넌트에서 사용중이었음)

	```jsx
	localStorage.getItem('token');
	```

**After**:
1. Private Route 생성하여 라우팅 단계에서 토큰 여부 확인하도록 기능 구현

	```jsx
	// PrivateRoute.jsx
	
	function PrivateRoute({ authenticationRequired }) {
	  const isLogin = token.getToken();
	
	// 인증이 필요한 페이지인데 토큰이 있으면 todo 페이지 렌더링, 없으면 login 페이지로 이동
	  if (authenticationRequired) {
	    return isLogin ? <Outlet /> : <Navigate to='/' />;
	  }
	
	// 인증이 필요없는 페이지인데 토큰이 있으면 todo 페이지로, 없으면 login, signup 페이지 렌더링
	  return isLogin ? <Navigate to='/todo' /> : <Outlet />;
	}
	```

	```jsx
	// Router.jsx
	
	...
	function Router() {
	  return (
	    <BrowserRouter>
	      <Routes>
	        <Route element={<PrivateRoute authenticationRequired />}>
	          <Route path='/todo' element={<Todo />} />
	        </Route>
	        <Route element={<PrivateRoute authenticationRequired={false} />}>
	          <Route path='/' element={<Login />} />
	          <Route path='/signup' element={<SignUp />} />
	        </Route>
	      </Routes>
	    </BrowserRouter>
	  );
	}
	```

2. token 유틸 함수 생성하여 필요한 곳에서 import하여 사용할 수 있도록 개선 (PrivateRoute, Login, SignUp, Todo 컴포넌트에서 사용중)

	```jsx
	const token = {
	  setToken: (userToken) => localStorage.setItem('token', userToken),
	  getToken: () => localStorage.getItem('token'),
	};
	
	export default token;
	```
