### PR TITLE
refactor: Todo 컴포넌트 관심사 분리 및 UI/UX 개선

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,12 @@
 import Router from './routers/Router';
+import TodoContextProvider from './context/TodoContext';
 
 function App() {
-  return <Router />;
+  return (
+    <TodoContextProvider>
+      <Router />;
+    </TodoContextProvider>
+  );
 }
 
 export default App;

--- a/src/apis/instance.js
+++ b/src/apis/instance.js
@@ -17,4 +17,17 @@ export const todoInstance = axios.create({
   },
 });
 
-authInstance.interceptors.response.use((res) => token.setToken(res.data.access_token));
+authInstance.interceptors.response.use(
+  (res) => token.setToken(res.data.access_token),
+  (err) => {
+    let errorMessage;
+    switch (err.response.data.message) {
+      case 'Unauthorized':
+        errorMessage = '비밀번호를 확인해주세요!';
+        break;
+      default:
+        errorMessage = err.response.data.message;
+    }
+    return Promise.reject(errorMessage);
+  }
+);

--- a/src/apis/instance.js
+++ b/src/apis/instance.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import token from '../utils/token';
 
-const userToken = token.getToken();
-
 export const authInstance = axios.create({
   baseURL: `https://pre-onboarding-selection-task.shop/auth/`,
   headers: {
@@ -12,9 +10,6 @@ export const authInstance = axios.create({
 
 export const todoInstance = axios.create({
   baseURL: `https://pre-onboarding-selection-task.shop/todos`,
-  headers: {
-    Authorization: `Bearer ${userToken}`,
-  },
 });
 
 authInstance.interceptors.response.use(
@@ -31,3 +26,14 @@ authInstance.interceptors.response.use(
     return Promise.reject(errorMessage);
   }
 );
+
+todoInstance.interceptors.request.use((config) => {
+  if (!config.headers) {
+    return config;
+  }
+
+  const bearerToken = `Bearer ${token.getToken()}`;
+  config.headers.Authorization ??= bearerToken;
+
+  return config;
+});

--- a/src/components/Auth/Login.jsx
+++ b/src/components/Auth/Login.jsx
@@ -22,8 +22,15 @@ function Login() {
   async function onSubmitHandle(e) {
     e.preventDefault();
 
-    await authApi.login({ email: loginData.email, password: loginData.password });
-    navigate('/todo');
+    await authApi
+      .login({ email: loginData.email, password: loginData.password })
+      .then(() => {
+        alert('로그인이 완료되었습니다!');
+        navigate('/todo');
+      })
+      .catch((err) => {
+        alert(err);
+      });
   }
 
   return (

--- a/src/components/Auth/Logout.jsx
+++ b/src/components/Auth/Logout.jsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '../../styles/Style';
+import token from '../../utils/token';
+
+function Logout() {
+  const navigate = useNavigate();
+  const logoutHandle = () => {
+    token.delToken();
+    alert('정상적으로 로그아웃되었습니다. 또 만나요~');
+    navigate('/');
+  };
+
+  return (
+    <Button state='submit' onClick={logoutHandle}>
+      로그아웃
+    </Button>
+  );
+}
+
+export default Logout;

--- a/src/components/Auth/SignUp.jsx
+++ b/src/components/Auth/SignUp.jsx
@@ -21,9 +21,15 @@ function SignUp() {
   async function onSubmitHandle(e) {
     e.preventDefault();
 
-    await authApi.signup({ email: userData.email, password: userData.password });
-    alert('회원가입이 완료되었습니다!');
-    navigate('/todo');
+    await authApi
+      .signup({ email: userData.email, password: userData.password })
+      .then(() => {
+        alert('회원가입이 완료되었습니다!');
+        navigate('/todo');
+      })
+      .catch((err) => {
+        alert(err);
+      });
   }
   return (
     <Wrapper>

--- a/src/components/Todo/AddTodo.jsx
+++ b/src/components/Todo/AddTodo.jsx
@@ -1,0 +1,34 @@
+import { useContext, useState } from 'react';
+import todoApi from '../../apis/todo';
+import { TodoContext } from '../../context/TodoContext';
+import { Button, TodoInput } from '../../styles/Style';
+
+function AddTodo() {
+  const todoCtx = useContext(TodoContext);
+  const [text, setText] = useState('');
+
+  async function createTodo() {
+    if (text.trim().length === 0) {
+      alert('할 일을 작성해주세요.');
+      return;
+    }
+    await todoApi.createTodo({ todo: text });
+    alert('할 일이 등록되었어요!');
+    todoCtx.getTodos();
+    setText('');
+  }
+
+  return (
+    <div className='inputWrapper'>
+      <TodoInput
+        name='todoText'
+        placeholder='할 일을 입력해주세요.'
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <Button onClick={createTodo}>추가</Button>
+    </div>
+  );
+}
+
+export default AddTodo;

--- a/src/components/Todo/EditTodo.jsx
+++ b/src/components/Todo/EditTodo.jsx
@@ -1,0 +1,42 @@
+import React, { useContext, useState } from 'react';
+import todoApi from '../../apis/todo';
+import { TodoContext } from '../../context/TodoContext';
+import { Li, TodoBtn, TodoCheck, TodoInput } from '../../styles/Style';
+
+const EditTodo = () => {
+  const todoCtx = useContext(TodoContext);
+  const [enteredText, setEnteredText] = useState(todoCtx.updateData?.updateText);
+  const [isCompleted, setIsCompleted] = useState(todoCtx.updateData?.updateCompleted);
+
+  function checkedCompleted(e) {
+    setIsCompleted(e.currentTarget.checked);
+  }
+
+  async function updateHandle() {
+    const confirm = window.confirm('할 일을 수정하시겠습니까?');
+    if (confirm) {
+      await todoApi.updateTodo(todoCtx.updateData?.updateId, { todo: enteredText, isCompleted });
+      todoCtx.updateModeHandle();
+      todoCtx.getTodos();
+    }
+  }
+
+  function cancelHandle() {
+    todoCtx.updateModeHandle();
+  }
+
+  return (
+    <Li key={todoCtx.updateData?.updateId}>
+      <TodoCheck type='checkbox' id='checkbox' checked={isCompleted} onChange={checkedCompleted} />
+      <TodoInput value={enteredText} onChange={(e) => setEnteredText(e.target.value)} />
+      <TodoBtn state={'submit'} onClick={updateHandle}>
+        제출
+      </TodoBtn>
+      <TodoBtn state={'del'} onClick={cancelHandle}>
+        취소
+      </TodoBtn>
+    </Li>
+  );
+};
+
+export default EditTodo;

--- a/src/components/Todo/Todo.jsx
+++ b/src/components/Todo/Todo.jsx
@@ -1,27 +1,16 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useContext } from 'react';
+import AddTodo from './AddTodo';
 import EditTodo from './EditTodo';
 import todoApi from '../../apis/todo';
 import { TodoContext } from '../../context/TodoContext';
-import { Wrapper, TodoInput, Button, TodoBtn, Span, Li, Ul } from '../../styles/Style';
+import { Wrapper, TodoBtn, Span, Li, Ul } from '../../styles/Style';
 
 function Todo() {
   const todoCtx = useContext(TodoContext);
-  const [text, setText] = useState('');
 
   useEffect(() => {
     todoCtx.getTodos();
   }, []);
-
-  async function createTodo() {
-    if (text.trim().length === 0) {
-      alert('할 일을 작성해주세요.');
-      return;
-    }
-    await todoApi.createTodo({ todo: text });
-    todoCtx.getTodos();
-    alert('할 일이 등록되었어요!');
-    setText('');
-  }
 
   async function deleteTodo(id) {
     const confirm = window.confirm('정말 삭제하시겠습니까?');
@@ -34,15 +23,7 @@ function Todo() {
   return (
     <Wrapper>
       <h1>투두 리스트</h1>
-      <div className='inputWrapper'>
-        <TodoInput
-          name='todoText'
-          placeholder='할 일을 입력해주세요.'
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-        />
-        <Button onClick={createTodo}>추가</Button>
-      </div>
+      <AddTodo />
       <Ul>
         {todoCtx.isUpdating ? (
           <EditTodo />

--- a/src/components/Todo/Todo.jsx
+++ b/src/components/Todo/Todo.jsx
@@ -24,21 +24,32 @@ function Todo() {
   }
 
   async function createTodo() {
+    if (text.trim().length === 0) {
+      alert('할 일을 작성해주세요.');
+      return;
+    }
     const todo = await todoApi.createTodo({ todo: text });
     setTodoData(todoData.concat(todo));
+    alert('할 일이 등록되었어요!');
     setText('');
     getTodo();
   }
 
   async function deleteTodo(id) {
-    await todoApi.deleteTodo(id);
-    getTodo();
+    const confirm = window.confirm('정말 삭제하시겠습니까?');
+    if (confirm) {
+      await todoApi.deleteTodo(id);
+      getTodo();
+    }
   }
 
   async function updateHandle() {
-    await todoApi.updateTodo(updateId, { todo: updateText, isCompleted });
-    setIsUpdate(false);
-    getTodo();
+    const confirm = window.confirm('할 일을 수정하시겠습니까?');
+    if (confirm) {
+      await todoApi.updateTodo(updateId, { todo: updateText, isCompleted });
+      setIsUpdate(false);
+      getTodo();
+    }
   }
 
   return (

--- a/src/components/Todo/Todo.jsx
+++ b/src/components/Todo/Todo.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import todoApi from '../../apis/todo';
-import { Wrapper, TodoInput, Button, TodoBtn, Span, LiWrapper } from '../../styles/Style';
+import { Wrapper, TodoInput, TodoCheck, Button, TodoBtn, Span, Li, Ul } from '../../styles/Style';
 
 function Todo() {
   const [todoData, setTodoData] = useState([]);
@@ -64,18 +64,21 @@ function Todo() {
         />
         <Button onClick={createTodo}>추가</Button>
       </div>
-      <ul style={{ padding: '0px' }}>
+      <Ul>
         {isUpdate ? (
-          <li key={updateId}>
-            <input
+          <Li key={updateId}>
+            <TodoCheck
               type='checkbox'
               id='checkbox'
               checked={isCompleted}
               onChange={checkedCompleted}
             />
             <TodoInput value={updateText} onChange={(e) => setUpdateText(e.target.value)} />
-            <TodoBtn onClick={() => updateHandle()}>제출</TodoBtn>
+            <TodoBtn state={'submit'} onClick={() => updateHandle()}>
+              제출
+            </TodoBtn>
             <TodoBtn
+              state={'del'}
               onClick={() => {
                 setIsUpdate(false);
                 setText('');
@@ -84,38 +87,46 @@ function Todo() {
             >
               취소
             </TodoBtn>
-          </li>
+          </Li>
         ) : (
-          <LiWrapper>
+          <>
             {todoData?.map((todo) => {
               return (
-                <li key={todo.id}>
-                  {todo.isCompleted ? (
-                    <Span state={'completed'}>완료!</Span>
-                  ) : (
-                    <Span state={'not'}>미완료</Span>
-                  )}
-                  {todo.todo}
-                  <TodoBtn
-                    state={'edit'}
-                    onClick={() => {
-                      setIsUpdate(true);
-                      setUpdateText(todo.todo);
-                      setIsCompleted(todo.isCompleted);
-                      setUpdateId(todo.id);
-                    }}
-                  >
-                    수정
-                  </TodoBtn>
-                  <TodoBtn state={'del'} onClick={() => deleteTodo(todo.id)}>
-                    삭제
-                  </TodoBtn>
-                </li>
+                <Li key={todo.id}>
+                  <div className='isCompleted'>
+                    {todo.isCompleted ? (
+                      <Span state={'completed'}>완료!</Span>
+                    ) : (
+                      <Span state={'not'}>미완료</Span>
+                    )}
+                  </div>
+                  <div className='todo'>{todo.todo}</div>
+                  <div className='positiveBtn'>
+                    <TodoBtn
+                      state={'edit'}
+                      onClick={() => {
+                        setIsUpdate(true);
+                        setUpdateText(todo.todo);
+                        setIsCompleted(todo.isCompleted);
+                        setUpdateId(todo.id);
+                      }}
+                    >
+                      수정
+                    </TodoBtn>
+                    <TodoBtn
+                      className='negativeBtn'
+                      state={'del'}
+                      onClick={() => deleteTodo(todo.id)}
+                    >
+                      삭제
+                    </TodoBtn>
+                  </div>
+                </Li>
               );
             })}
-          </LiWrapper>
+          </>
         )}
-      </ul>
+      </Ul>
     </Wrapper>
   );
 }

--- a/src/components/Todo/Todo.jsx
+++ b/src/components/Todo/Todo.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useContext } from 'react';
 import AddTodo from './AddTodo';
 import TodoList from './TodoList';
 import EditTodo from './EditTodo';
+import Logout from '../Auth/Logout';
 import { TodoContext } from '../../context/TodoContext';
 import { Wrapper, Ul } from '../../styles/Style';
 
@@ -17,6 +18,7 @@ function Todo() {
       <h1>투두 리스트</h1>
       <AddTodo />
       <Ul>{todoCtx.isUpdating ? <EditTodo /> : <TodoList />}</Ul>
+      <Logout />
     </Wrapper>
   );
 }

--- a/src/components/Todo/Todo.jsx
+++ b/src/components/Todo/Todo.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useContext } from 'react';
 import AddTodo from './AddTodo';
+import TodoList from './TodoList';
 import EditTodo from './EditTodo';
-import todoApi from '../../apis/todo';
 import { TodoContext } from '../../context/TodoContext';
-import { Wrapper, TodoBtn, Span, Li, Ul } from '../../styles/Style';
+import { Wrapper, Ul } from '../../styles/Style';
 
 function Todo() {
   const todoCtx = useContext(TodoContext);
@@ -12,57 +12,11 @@ function Todo() {
     todoCtx.getTodos();
   }, []);
 
-  async function deleteTodo(id) {
-    const confirm = window.confirm('정말 삭제하시겠습니까?');
-    if (confirm) {
-      await todoApi.deleteTodo(id);
-      todoCtx.getTodos();
-    }
-  }
-
   return (
     <Wrapper>
       <h1>투두 리스트</h1>
       <AddTodo />
-      <Ul>
-        {todoCtx.isUpdating ? (
-          <EditTodo />
-        ) : (
-          <>
-            {todoCtx.todos?.map((todo) => {
-              return (
-                <Li key={todo.id}>
-                  <div className='isCompleted'>
-                    {todo.isCompleted ? (
-                      <Span state={'completed'}>완료!</Span>
-                    ) : (
-                      <Span state={'not'}>미완료</Span>
-                    )}
-                  </div>
-                  <div className='todo'>{todo.todo}</div>
-                  <div className='positiveBtn'>
-                    <TodoBtn
-                      state={'edit'}
-                      onClick={() => {
-                        todoCtx.updateModeHandle(todo.id, todo.todo, todo.isCompleted);
-                      }}
-                    >
-                      수정
-                    </TodoBtn>
-                    <TodoBtn
-                      className='negativeBtn'
-                      state={'del'}
-                      onClick={() => deleteTodo(todo.id)}
-                    >
-                      삭제
-                    </TodoBtn>
-                  </div>
-                </Li>
-              );
-            })}
-          </>
-        )}
-      </Ul>
+      <Ul>{todoCtx.isUpdating ? <EditTodo /> : <TodoList />}</Ul>
     </Wrapper>
   );
 }

--- a/src/components/Todo/TodoList.jsx
+++ b/src/components/Todo/TodoList.jsx
@@ -1,0 +1,44 @@
+import { useContext } from 'react';
+import todoApi from '../../apis/todo';
+import { TodoContext } from '../../context/TodoContext';
+import { Li, Span, TodoBtn } from '../../styles/Style';
+
+function TodoList() {
+  const todoCtx = useContext(TodoContext);
+
+  async function deleteTodo(id) {
+    const confirm = window.confirm('정말 삭제하시겠습니까?');
+    if (confirm) {
+      await todoApi.deleteTodo(id);
+      todoCtx.getTodos();
+    }
+  }
+
+  return todoCtx.todos?.map((todo) => (
+    <Li key={todo.id}>
+      <div className='isCompleted'>
+        {todo.isCompleted ? (
+          <Span state={'completed'}>완료!</Span>
+        ) : (
+          <Span state={'not'}>미완료</Span>
+        )}
+      </div>
+      <div className='todo'>{todo.todo}</div>
+      <div className='positiveBtn'>
+        <TodoBtn
+          state={'edit'}
+          onClick={() => {
+            todoCtx.updateModeHandle(todo.id, todo.todo, todo.isCompleted);
+          }}
+        >
+          수정
+        </TodoBtn>
+        <TodoBtn className='negativeBtn' state={'del'} onClick={() => deleteTodo(todo.id)}>
+          삭제
+        </TodoBtn>
+      </div>
+    </Li>
+  ));
+}
+
+export default TodoList;

--- a/src/context/TodoContext.js
+++ b/src/context/TodoContext.js
@@ -1,0 +1,44 @@
+import { createContext, useState } from 'react';
+import todoApi from '../apis/todo';
+
+const defaultValue = {
+  getTodos: () => {},
+  todos: [],
+  isUpdating: false,
+  updateData: {},
+  updateModeHandle: (id, text, completed) => {},
+};
+
+export const TodoContext = createContext(defaultValue);
+
+function TodoContextProvider({ children }) {
+  const [todos, setTodos] = useState([]);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [updateData, setUpdateData] = useState({});
+
+  const getTodos = async () => {
+    const todos = await todoApi.getTodos();
+    setTodos(todos);
+  };
+
+  const updateMode = (id, text, completed) => {
+    setIsUpdating((prevMode) => !prevMode);
+    setUpdateData({
+      updateId: id,
+      updateText: text,
+      updateCompleted: completed,
+    });
+  };
+
+  const todoContext = {
+    getTodos,
+    todos,
+    isUpdating,
+    updateData,
+    updateModeHandle: updateMode,
+  };
+
+  return <TodoContext.Provider value={todoContext}>{children}</TodoContext.Provider>;
+}
+
+export default TodoContextProvider;

--- a/src/styles/Style.jsx
+++ b/src/styles/Style.jsx
@@ -10,12 +10,26 @@ export const Wrapper = styled.section`
   margin: 0 auto;
 `;
 
-export const LiWrapper = styled.ul`
-  margin-bottom: 10px;
+export const Ul = styled.ul`
+  padding: 0;
+  margin-top: 50px;
+`;
 
-  & {
-    text-align: center;
-    list-style: none;
+export const Li = styled.li`
+  margin-bottom: 20px;
+  list-style: none;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .isCompleted {
+    margin: 0 auto;
+  }
+
+  .todo {
+    border-bottom: 1px solid gray;
+    width: 200px;
   }
 `;
 
@@ -38,6 +52,7 @@ function getBackColor(state) {
     case 'not':
       return '#CD5C5C';
     case 'edit':
+    case 'submit':
       return '#F5F5F5';
     case 'del':
       return '#FA8072';
@@ -66,9 +81,11 @@ export const TodoInput = styled.input`
   border: none;
   border-bottom: solid;
 
-  margin-bottom: 10px;
   width: 200px;
   height: 25px;
+
+  font-size: 18px;
+  outline: none;
 `;
 
 export const Button = styled.button`
@@ -82,12 +99,19 @@ export const Button = styled.button`
   cursor: pointer;
 `;
 
+export const TodoCheck = styled.input`
+  width: 25px;
+  height: 25px;
+  margin: 0;
+  margin-right: 10px;
+`;
+
 export const TodoBtn = styled.button`
   background-color: ${(props) => getBackColor(props.state)};
   color: ${(props) => (props.state === 'del' ? '#fff' : '#000')};
 
   padding: 5px 10px;
-  margin-left: 5px;
+  margin-left: 10px;
 
   border: none;
   border-radius: 5px;

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,6 +1,7 @@
 const token = {
   setToken: (userToken) => localStorage.setItem('token', userToken),
   getToken: () => localStorage.getItem('token'),
+  delToken: () => localStorage.removeItem('token'),
 };
 
 export default token;


### PR DESCRIPTION
### 관련 이슈

#1 #7

### 고민했던 점

**1. 상태 관리를 어떻게 할까?**

`React`에서 `props drilling`을 피하기 위해 또는 전역 상태관리를 하기 위해 만들어진 라이브러리는 다양하다.
그 중 내가 사용해봤던 것은 `Redux`, `Recoil`이고 `React`의 `Context API`도 사용해보았다.
`Todo` 컴포넌트를 쪼개면서 `todo` 데이터를 관리해야 했는데, 어떤 방법으로 관리할지 고민을 했다.

저장해야 할 상태는 등록되어있는 todo 리스트, 할 일 수정 중인지에 대한 상태, 수정할 데이터 정도였고
규모가 큰 프로젝트는 아니기 때문에 라이브러리를 사용하는 것 보단 Context API로 구현하자는 결론을 냈다.

**2. 로그인 후 `todo` 페이지로 이동될 때 목록이 안불러와진다**

로그인 후 `todo` 페이지로 이동이 되는데, `AxiosError`가 발생하면서 `todo` 리스트가 불러와지지 않았다.
![Untitled](https://user-images.githubusercontent.com/85178602/214867078-b6c169f6-678c-44a0-a79f-58b1f8fed498.png)
하지만 새로고침을 하면 정상적으로 통신이 되어 리스트가 렌더링 되는 것을 확인하였다.

`Unauthorized` 에러가 발생한 것을 보고 `axios` 통신 시 `token`이 잘 불러와지는지 확인한 결과 `token`이 `null`로 출력되었다.
이후 새로고침을 하면 정상적으로 `token`이 출력된다.

`auth interceptor`를 구현했기 때문에 로그인이 되면 바로 스토리지에 정상적으로 토큰이 저장되는 것을 확인하였고,
`Todo GET`요청을 하기 전 `interceptor`로 토큰이 없을 시 다시 스토리지에서 토큰을 가져와 저장할 수 있도록 코드를 수정하였다.

### 변경 사항

**Before**: todo interceptor 설정 전
```jsx
const userToken = token.getToken();

export const todoInstance = axios.create({
  baseURL: `https://pre-onboarding-selection-task.shop/todos`,
  headers: {
    Authorization: `Bearer ${userToken}`,
  },
});
```

**After**: todo interceptor 설정 후
```jsx
export const todoInstance = axios.create({
  baseURL: `https://pre-onboarding-selection-task.shop/todos`,
});

todoInstance.interceptors.request.use((config) => {
  if (!config.headers) {
    return config;
  }

  const bearerToken = `Bearer ${token.getToken()}`;
  config.headers.Authorization ??= bearerToken;

  return config;
});
```
---

**Before**: Todo 컴포넌트 분리 전

Todo.jsx 코드 줄 수: 124줄

```
Todo
 ┗ Todo.jsx
```

**After**: Todo 컴포넌트 분리 후

Todo.jsx 코드 줄 수: 27줄
기존 기능들은 각 컴포넌트에 구현

```
Todo
 ┣ AddTodo.jsx
 ┣ EditTodo.jsx
 ┣ Todo.jsx
 ┗ TodoList.jsx
```